### PR TITLE
Option to calculate and display next max hit

### DIFF
--- a/src/main/java/com/maxhit/MaxHitConfig.java
+++ b/src/main/java/com/maxhit/MaxHitConfig.java
@@ -18,8 +18,8 @@ public interface MaxHitConfig extends Config {
 	@ConfigItem(
 			keyName = "showNextMaxHit",
 			name = "Calculate next max hit",
-			description = "Mouse over to show the options to reach the next max hit like " +
-					"strength/ranged levels, bonus or prayer boosts",
+			description = "Mouse over the max hit to show the options to reach the next max hit " +
+					"like strength/ranged levels, bonus or prayer boosts",
 			position = 2
 	)
 	default boolean showNextMaxHit() { return true; }

--- a/src/main/java/com/maxhit/MaxHitConfig.java
+++ b/src/main/java/com/maxhit/MaxHitConfig.java
@@ -16,10 +16,19 @@ public interface MaxHitConfig extends Config {
 	default boolean maxHit() { return true; }
 
 	@ConfigItem(
+			keyName = "showNextMaxHit",
+			name = "Calculate next max hit",
+			description = "Mouse over to show the options to reach the next max hit like " +
+					"strength/ranged levels, bonus or prayer boosts",
+			position = 2
+	)
+	default boolean showNextMaxHit() { return true; }
+
+	@ConfigItem(
 			keyName = "showSpec",
 			name = "Show Max Spec",
 			description = "Show max spec in current setup",
-			position = 2
+			position = 3
 	)
 	default boolean showSpec() { return true; }
 
@@ -27,7 +36,7 @@ public interface MaxHitConfig extends Config {
 			keyName = "showMagic",
 			name = "Show Magic",
 			description = "Show max hit in current setup with selected spell",
-			position = 3
+			position = 4
 	)
 	default boolean showMagic() { return false; }
 
@@ -36,7 +45,7 @@ public interface MaxHitConfig extends Config {
 			keyName = "spellChoice",
 			name = "Spell",
 			description = "Choose spell to calculate max",
-			position = 4
+			position = 5
 	)
 	default MagicSpell spellChoice() { return MagicSpell.ICE_BARRAGE; }
 
@@ -44,7 +53,7 @@ public interface MaxHitConfig extends Config {
 			keyName = "applyCharge",
 			name = "Apply Charge Spell",
 			description = "Calculate max hit of spell using charge (god spells)",
-			position = 5
+			position = 6
 	)
 	default boolean applyCharge() { return false; }
 
@@ -52,7 +61,7 @@ public interface MaxHitConfig extends Config {
 			keyName = "inventoryWeapons",
 			name = "Inventory Weapons' Max Hits",
 			description = "Shows max hit of weapons in inventory. Assumes highest level prayer is used",
-			position = 6
+			position = 7
 	)
 	default boolean inventoryWeapons() { return false; }
 
@@ -60,7 +69,7 @@ public interface MaxHitConfig extends Config {
 			keyName = "inventoryWeaponsSpecial",
 			name = "Inventory Weapons' Max Specs",
 			description = "Shows max spec of weapons in inventory",
-			position = 7
+			position = 8
 	)
 	default boolean invetoryWeaponsSpecial() { return false; }
 
@@ -69,7 +78,7 @@ public interface MaxHitConfig extends Config {
 			name = "Inventory Selective Spec",
 			description = "Shows spec max if weapon has spec, otherwise shows normal max. " +
 					"Do not use with previous two options",
-			position = 8
+			position = 9
 	)
 	default boolean inventorySelectiveSpecial() { return false; }
 }

--- a/src/main/java/com/maxhit/MaxHitOverlay.java
+++ b/src/main/java/com/maxhit/MaxHitOverlay.java
@@ -1,5 +1,6 @@
 package com.maxhit;
 
+import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
@@ -10,25 +11,35 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 import javax.inject.Inject;
 import java.awt.*;
 import java.util.HashMap;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.ColorUtil;
+
 
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 
 public class MaxHitOverlay extends Overlay {
 
+    private static final Color COMBAT_LEVEL_COLOUR = new Color(0xff981f);
+
     private MaxHitPlugin plugin;
     private MaxHitConfig config;
+    private Client client;
+    private TooltipManager tooltipManager;
 
     private PanelComponent panelComponent = new PanelComponent();
 
 
     @Inject
-    public MaxHitOverlay(MaxHitPlugin plugin, MaxHitConfig config) {
+    public MaxHitOverlay(MaxHitPlugin plugin, MaxHitConfig config, Client client, TooltipManager tooltipManager) {
         super(plugin);
         setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
         setLayer(OverlayLayer.ABOVE_SCENE);
         this.plugin = plugin;  //set plugin field to plugin object given as input
         this.config = config;
+        this.client = client;
+        this.tooltipManager = tooltipManager;
         getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Max hit overlay"));
     }
 
@@ -56,6 +67,12 @@ public class MaxHitOverlay extends Overlay {
                     .left("Magic Max Hit:")
                     .right(Double.toString(Math.floor(plugin.maxMagicHitBase())))
                     .build());
+        }
+
+        if (config.showNextMaxHit() && this.getBounds().contains(
+                client.getMouseCanvasPosition().getX(),
+                client.getMouseCanvasPosition().getY())) {
+            tooltipManager.add(new Tooltip(getNextMaxHitTooltip()));
         }
 
 
@@ -95,5 +112,38 @@ public class MaxHitOverlay extends Overlay {
         }
 
         return panelComponent.render(graphics);
+    }
+
+    private String getNextMaxHitTooltip() {
+        NextMaxHit nextMaxHit = plugin.nextMaxHit();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(ColorUtil.wrapWithColorTag("Next max hit:", COMBAT_LEVEL_COLOUR));
+
+        if (nextMaxHit.strengthLevels > 0) {
+            sb.append("</br>").append(nextMaxHit.strengthLevels).append(" Strength levels");
+        }
+        else if (nextMaxHit.rangedLevels > 0) {
+            sb.append("</br>").append(nextMaxHit.rangedLevels).append(" Ranged levels");
+        }
+        else if (nextMaxHit.magicLevels > 0) {
+            sb.append("</br>").append(nextMaxHit.magicLevels).append(" Magic levels");
+        }
+
+        if (nextMaxHit.strengthBonus > 0) {
+            sb.append("</br>").append(nextMaxHit.strengthBonus).append(" Strength bonus");
+        }
+        else if (nextMaxHit.rangedBonus > 0) {
+            sb.append("</br>").append(nextMaxHit.rangedBonus).append(" Ranged bonus");
+        }
+        else if (nextMaxHit.magicBonus > 0) {
+            sb.append("</br>").append(nextMaxHit.magicBonus).append(" % Magic damage");
+        }
+
+        if (nextMaxHit.prayerBoost > 0) {
+            sb.append("</br>").append(nextMaxHit.prayerBoost).append(" % Prayer boost");
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/maxhit/MaxHitPlugin.java
+++ b/src/main/java/com/maxhit/MaxHitPlugin.java
@@ -969,7 +969,7 @@ public class MaxHitPlugin extends Plugin {
 		// Remove void set effects
 		if (itemSet(equippedWeaponID()).contains("oid")) {
 		    reverseEffectiveStrengthLevel /= setBonus;
-        }
+        	}
 
 		final double levelNew = Math.ceil(reverseEffectiveStrengthLevel / pray);
 		final double levelDiff = levelNew - level;

--- a/src/main/java/com/maxhit/NextMaxHit.java
+++ b/src/main/java/com/maxhit/NextMaxHit.java
@@ -1,0 +1,11 @@
+package com.maxhit;
+
+public class NextMaxHit {
+    public int strengthLevels;
+    public int rangedLevels;
+    public int magicLevels;
+    public int strengthBonus;
+    public int rangedBonus;
+    public int magicBonus;
+    public int prayerBoost;
+}


### PR DESCRIPTION
Adds a config option `Calculate next max hit` that adds a tooltip to the max hit overlay indicating the different options to increase the current max hit by 1. The options are strength/ranged levels, strength/ranged bonus, magic damage % and prayer % boost, and depends on the current active combat style.
![image](https://user-images.githubusercontent.com/33559295/130525274-2fd816d7-8027-4003-b6d3-87224b0f89e5.png)
I have not been able to test if this reverse max hit calculation works as intended with void set effects, non-void set effects and magic spells.
